### PR TITLE
Fixes #49: Resolves critical foreign key bug with user_option_link

### DIFF
--- a/console/migrations/m160617_035238_fix_incorrect_foreign_key_on_user_option_link.php
+++ b/console/migrations/m160617_035238_fix_incorrect_foreign_key_on_user_option_link.php
@@ -1,0 +1,19 @@
+<?php
+
+use yii\db\Migration;
+
+class m160617_035238_fix_incorrect_foreign_key_on_user_option_link extends Migration
+{
+  public function safeUp()
+  {
+    $this->dropForeignKey('option_link_option_fk', '{{%user_option_link}}');
+    $this->delete('{{%user_option_link}}', 'option_id = 39 OR option_id = 40');
+    $this->addForeignKey('option_link_option_fk', '{{%user_option_link}}', 'option_id', '{{%option}}', 'id', 'CASCADE', 'CASCADE');
+  }
+
+  public function safeDown()
+  {
+    echo "m160617_035238_fix_incorrect_foreign_key_on_user_option_link cannot be reverted and THAT'S OKAY.\n";
+    return true;
+  }
+}


### PR DESCRIPTION
A foreign key that I had written in 2014 for the user_option_link table
was incorrect, but only began affecting users in the last day, when the
user_id values grew larger than 130.

The foreign key constraint incorrectly insured that rows inserted into
the user_option_link table had a user_id that was a valid id in the
option table (?? wat). There were ~130 options, so it didn't cause any
issues....until more than 130 users existed in the db. Then all
check-ins for user_ids > 130 were rejected.

This migration fixes that.
