### PR TITLE
Fixes #58: Fixing captcha and mail (and mailer) for default install

### DIFF
--- a/common/config/main.php
+++ b/common/config/main.php
@@ -5,7 +5,12 @@ return [
   'extensions' => require(__DIR__ . '/../../vendor/yiisoft/extensions.php'),
   'components' => [
     'cache' => [
-      'class' => 'yii\caching\DummyCache', // OR USE MEMCACHE OR SOMETHING
+      'class' => 'yii\caching\FileCache', // OR USE MEMCACHE OR SOMETHING
+    ],
+    'mailer' => [
+      'class' => 'yii\swiftmailer\Mailer',
+      'viewPath' => '@common/mail',
+      'useFileTransport' => true,
     ],
   ],
 ];

--- a/common/config/params.php
+++ b/common/config/params.php
@@ -1,6 +1,6 @@
 <?php
 return [
-  'adminEmail' => '',
-  'supportEmail' => '',
+  'adminEmail' => 'admin@fasterscaleapp.com',
+  'supportEmail' => 'support@fasterscaleapp.com',
   'user.passwordResetTokenExpire' => 3600,
 ];


### PR DESCRIPTION
The captcha wasn't working out of the box because it was trying to
store the captcha string in the user session, which was stored in the
cache. DummyCache isn't a real cache, so it wasn't able to store the
captcha string. So the captcha never worked.

Also fixing email and the mailer so that it works by default, storing
each sent email in a flat file in site/runtime/mail/. Now the app won't
error out when a developer tries to send email from their local machine.

This commit includes:
- Swapping DummyCache for FileCache (a real cache)
- Fixing mailer by configuring 'useFileTransport' option to be true by
  default
