### PR TITLE
No idea how this one slipped past me.

### DIFF
--- a/site/controllers/CheckinController.php
+++ b/site/controllers/CheckinController.php
@@ -109,7 +109,6 @@ class CheckinController extends \yii\web\Controller
       $date = Time::getLocalDate();
 
     list($start, $end) = Time::getUTCBookends($date);
-    $utc_date = Time::convertLocalToUTC($date);
 
     $form = new CheckinForm();
     $form->setOptions(User::getUserOptions($date));
@@ -117,7 +116,6 @@ class CheckinController extends \yii\web\Controller
     return $this->render('view', [
       'model'              => $form,
       'actual_date'        => $date,
-      'utc_date'           => $utc_date,
       'categories'         => Category::find()->asArray()->all(),
       'optionsList'        => Option::getAllOptions(),
       'score'              => UserOption::getDailyScore($date),

--- a/site/views/checkin/view.php
+++ b/site/views/checkin/view.php
@@ -26,7 +26,7 @@ function checkboxItemTemplate($index, $label, $name, $checked, $value) {
   <div class='btn-group' role='group'>
 <?= yii\jui\DatePicker::widget([
   'name' => 'attributeName', 
-  'value' => $utc_date,
+  'value' => $actual_date,
   'options' => ['class'=> 'btn btn-default datepicker', 'readonly' => true],
   'dateFormat' => 'yyyy-MM-dd', 
   'clientOptions' => [


### PR DESCRIPTION
The date in the /checkin/view datepicker field was often wrong for many
different timezones. That field was the UTC date instead of the user's
date. This fixes that.
