### PR TITLE
Fixes 63 change created at updated at columns to be timestamps

### DIFF
--- a/common/models/User.php
+++ b/common/models/User.php
@@ -67,13 +67,10 @@ class User extends ActiveRecord implements IdentityInterface
   public function behaviors()
   {
     return [
-      'timestamp' => [
+      [
         'class' => 'yii\behaviors\TimestampBehavior',
-        'attributes' => [
-          ActiveRecord::EVENT_BEFORE_INSERT => ['created_at', 'updated_at'],
-          ActiveRecord::EVENT_BEFORE_UPDATE => ['updated_at'],
-        ],
-      ],
+        'value' => new yii\db\Expression('NOW()'),
+      ]
     ];
   }
 

--- a/console/migrations/m161021_152813_alter_user_table_make_created_at_updated_at_be_timestamps.php
+++ b/console/migrations/m161021_152813_alter_user_table_make_created_at_updated_at_be_timestamps.php
@@ -6,6 +6,15 @@ class m161021_152813_alter_user_table_make_created_at_updated_at_be_timestamps e
 {
     public function safeUp()
     {
+      // rename these columns to be consistent
+      $this->renameColumn('{{%user_option_link}}', 'date', 'created_at');
+      $this->renameColumn('{{%question}}', 'date', 'created_at');
+
+      // add a timezone to these timestamp columns
+      $this->execute("SET LOCAL timezone='UTC';");
+      $this->alterColumn('{{%user_option_link}}', 'created_at', 'TIMESTAMP WITH TIMEZONE');
+      $this->alterColumn('{{%question}}', 'created_at', 'TIMESTAMP WITH TIMEZONE');
+
       $this->alterColumn('{{%user}}', 'created_at', "TIMESTAMP WITH TIME ZONE USING TIMESTAMP WITH TIME ZONE 'epoch' + created_at * interval '1 second';");
       $this->alterColumn('{{%user}}', 'updated_at', "TIMESTAMP WITH TIME ZONE USING TIMESTAMP WITH TIME ZONE 'epoch' + updated_at * interval '1 second';");
     }
@@ -14,7 +23,19 @@ class m161021_152813_alter_user_table_make_created_at_updated_at_be_timestamps e
     {
       echo "This doesn't work right now... :(\n";
       return false;
-      //$this->alterColumn("{{%user}}", "created_at", "INTEGER NOT NULL");
-      //$this->alterColumn("{{%user}}", "updated_at", "INTEGER NOT NULL");
+
+      // somehow reverse these
+      // select extract(epoch from created_at)::integer as created_at from "user";
+      //$this->alterColumn('{{%user}}', 'created_at', "TIMESTAMP WITH TIME ZONE USING TIMESTAMP WITH TIME ZONE 'epoch' + created_at * interval '1 second';");
+      //$this->alterColumn('{{%user}}', 'updated_at', "TIMESTAMP WITH TIME ZONE USING TIMESTAMP WITH TIME ZONE 'epoch' + updated_at * interval '1 second';");
+
+      // add a timezone to these timestamp columns
+      $this->execute("SET LOCAL timezone='UTC';");
+      $this->alterColumn('{{%user_option_link}}', 'created_at', 'TIMESTAMP WITHOUT TIMEZONE');
+      $this->alterColumn('{{%question}}', 'created_at', 'TIMESTAMP WITHOUT TIMEZONE');
+      
+      // rename these columns to be consistent
+      $this->renameColumn('{{%user_option_link}}', 'created_at', 'date');
+      $this->renameColumn('{{%question}}', 'created_at', 'date');
     }
 }

--- a/console/migrations/m161021_152813_alter_user_table_make_created_at_updated_at_be_timestamps.php
+++ b/console/migrations/m161021_152813_alter_user_table_make_created_at_updated_at_be_timestamps.php
@@ -1,0 +1,20 @@
+<?php
+
+use yii\db\Migration;
+
+class m161021_152813_alter_user_table_make_created_at_updated_at_be_timestamps extends Migration
+{
+    public function safeUp()
+    {
+      $this->alterColumn('{{%user}}', 'created_at', "TIMESTAMP WITH TIME ZONE USING TIMESTAMP WITH TIME ZONE 'epoch' + created_at * interval '1 second';");
+      $this->alterColumn('{{%user}}', 'updated_at', "TIMESTAMP WITH TIME ZONE USING TIMESTAMP WITH TIME ZONE 'epoch' + updated_at * interval '1 second';");
+    }
+
+    public function safeDown()
+    {
+      echo "This doesn't work right now... :(\n";
+      return false;
+      //$this->alterColumn("{{%user}}", "created_at", "INTEGER NOT NULL");
+      //$this->alterColumn("{{%user}}", "updated_at", "INTEGER NOT NULL");
+    }
+}


### PR DESCRIPTION
This will likely take a little longer to do than I had anticipated. It's not super straightforward to alter integer columns to timestamps -- especially to do in a method that is DMBS-flavor agnostic.

Currently, the code as it is now gets us mostly to the destination -- but in postgres only. Which completely destroys the DBMS choice and flexibility I've put some effort into maintaining.

This is on the lower-priority backburner for now until I figure out an acceptable solution.
