### PR TITLE
bumping minimum version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
+  - 7.1
 #  - hhvm
 
 # faster builds on new travis setup not using sudo

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## Getting Started
 These instructions will help you get a local installation set up for development and testing purposes. See the deployment instructions for how to deploy this to a live system.
 ### Prerequisites
-* PHP >= 5.6
+* PHP >= 7.0
 * Composer
 * A type of SQL compatible with Yii2's ActiveRecord:
   * MySQL 4.1 or later

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "minimum-stability": "dev",
   "require": {
-    "php": ">=5.6",
+    "php": ">=7.0",
     "yiisoft/yii2": ">=2.0.6",
     "yiisoft/yii2-bootstrap": "~2.0.0",
     "yiisoft/yii2-swiftmailer": "~2.0.0",


### PR DESCRIPTION
Testing out a minimum version bump. 5.6 is erroring out because of dependencies.