### PR TITLE
Removing Google Analytics

### DIFF
--- a/site/views/layouts/main.php
+++ b/site/views/layouts/main.php
@@ -87,18 +87,6 @@ if($hash = Utility::getRevHash()) {
           </div>
         </div>
     </footer>
-
-    <script type='text/javascript'>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-56659433-1', 'auto');
-	ga('create', 'UA-56659433-1', {'siteSpeedSampleRate': 100});
-        ga('send', 'pageview')
-    </script>
-
     <?php $this->endBody() ?>
 </body>
 </html>

--- a/site/views/site/faq.php
+++ b/site/views/site/faq.php
@@ -25,7 +25,7 @@ $this->registerMetaTag([
   <div>
     <strong>What do you do with my data?</strong>
     <p class="indent">Nothing. We don't sell it, trade it, barter it, exchange it, or give it away. Only you can download all of your data, at any time, by visiting your profile page and exporting it. You can delete all of your data (and account) on your profile page as well.</p>
-    <p class="indent">NOTE: we might use traffic analytics software (like Google Analytics) to give us better insight into the usage of the Faster Scale App. Additionally, backups of this server and database are taken regularly, encrypted, stored for a relatively short period, and then deleted on a rotating basis.</p>
+    <p class="indent">NOTE: Backups of this server and database are taken regularly, encrypted, stored for a relatively short period, and then deleted on a rotating basis.</p>
   </div>
 
   <div>


### PR DESCRIPTION
There are definite privacy concerns with Google Analytics. Additionally,
we don't use it that much...not enough to justify the privacy concerns.
So goodbye GA.