### PR TITLE
Moving asset minification away from YUI Compressor and Closure-Compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ composer exec -v codecept run --coverage --coverage-xml --coverage-html --ansi
 ```
 
 ## Assets
-We have built-in support for compilation of JS and CSS/SCSS assets. Ensure you have both Closure Compiler and Yui Compressor installed and ensure you have uncommented the respective lines in ```site/config/main.php``` or overridden them in ```site/config/main-local.php```. Then execute:
+We have built-in support for minimizing JS and CSS assets. Ensure the npm packages uglifyjs and uglifycss are installed via ```npm install uglifyjs uglifycss -g```. Then uncommented the respective assetManager lines in ```site/config/main.php``` or override them in ```site/config/main-local.php```. Then execute:
 ```bash
 ./yii asset site/assets/assets.php site/assets/assets-compressed.php
 ```

--- a/site/assets/assets.php
+++ b/site/assets/assets.php
@@ -9,9 +9,9 @@
 
 return [
     // Adjust command/callback for JavaScript files compressing:
-    'jsCompressor' => 'closure-compiler --js {from} --js_output_file {to}',
+    'jsCompressor' => 'uglifyjs {from} --compress --mangle --output {to}',
     // Adjust command/callback for CSS files compressing:
-    'cssCompressor' => 'yui-compressor --type css {from} -o {to}',
+    'cssCompressor' => 'uglifycss --debug --ugly-comments {from} > {to}',
     // The list of asset bundles to compress:
     'bundles' => [
         'site\assets\AppAsset',


### PR DESCRIPTION
The Java dependency always been obnoxious. When I migrated this to the
new server Closure-Compiler didn't work for some reason. Instead of
investigating why, I've migrated us to UgilifyJS (and UglifyCSS for
good measure). I love not having to worry about having Java installed,
and npm is (or _should_ be) installed on every machine ever. Just kidding.