### PR TITLE
Fixes #107: Fixing Capistrano deprecation notice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /components
 !/common/components
 /node_modules
+/log

--- a/Capfile
+++ b/Capfile
@@ -4,6 +4,9 @@ require 'capistrano/setup'
 # Includes default deployment tasks
 require 'capistrano/deploy'
 
+require "capistrano/scm/git"
+install_plugin Capistrano::SCM::Git
+
 # Includes tasks from other gems included in your Gemfile
 #
 # For documentation on these, see for example:

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -5,9 +5,6 @@ set :staging, :production
 set :application, 'Checkin'
 set :repo_url, 'ssh://git@github.com/CorWatts/emotionalcheckin.git'
 
-# Default value for :scm is :git
-set :scm, :git
-
 set :keep_releases, 3
 
 set :linked_files, %w{common/config/main-local.php common/config/params-local.php console/config/main-local.php console/config/params-local.php site/config/main-local.php site/config/params-local.php .ruby-gemset .ruby-version}
@@ -21,7 +18,7 @@ namespace :deploy do
   desc 'Restarting application'
   task :restart do
     on roles(:app) do
-      execute "sudo service php7.0-fpm restart"
+      execute "sudo service php7.1-fpm restart"
     end
   end
 


### PR DESCRIPTION
Fixes #107 

Recent versions of capistrano show a deprecation notice regarding how the SCM is specified to be Git.

This fixes that, updates the php-fpm version number, and adds another item to the .gitignore file.