### PR TITLE
Fixing a rogue flash message that appears on the checkin/view page

### DIFF
--- a/site/controllers/CheckinController.php
+++ b/site/controllers/CheckinController.php
@@ -51,7 +51,6 @@ class CheckinController extends \yii\web\Controller
 
       // delete cached scores
       Yii::$app->cache->delete("scores_of_last_month_".Yii::$app->user->id."_".Time::getLocalDate());
-      Yii::$app->session->setFlash('success', 'Answer the questions below to compete your checkin.');
       return $this->redirect(['questions']);
 
     } else {
@@ -87,9 +86,9 @@ class CheckinController extends \yii\web\Controller
         $score = UserOption::getDailyScore();
         if($user->isOverThreshold($score)) {
           $user->sendEmailReport($date);
-          Yii::$app->session->setFlash('warning', 'Your checkin is complete. A notification has been sent to your report partners because of your high score. Reach out to them!');
+          Yii::$app->session->setFlash('warning', 'Your check-in is complete. A notification has been sent to your report partners because of your high score. Reach out to them!');
         } else {
-          Yii::$app->session->setFlash('success', 'Your emotions have been logged!');
+          Yii::$app->session->setFlash('success', 'Your behaviors and processing questions have been logged!');
         }
 
         return $this->redirect(['view']);

--- a/site/views/checkin/questions.php
+++ b/site/views/checkin/questions.php
@@ -32,7 +32,8 @@ foreach($options as $option) {
 }
 ?>
 <h1>Check-In Questions</h1>
-<p>In each category, select one feeling, then answer the related questions.</p>
+<p>Answer the questions below to compete your check-in.</p>
+<p>In each category, select one feeling. Then answer the related questions.</p>
 <?php
 $form = ActiveForm::begin([
   'id' => 'checkin-form',


### PR DESCRIPTION
The message that normally only appears on the questions page appeared
on the view page if you scored a 0 and skipped the processing questions.

This has been fixed. Also, that message is no longer a flash message.