### PR TITLE
Cleaning up various inconsistencies dealing with page titles and terms

### DIFF
--- a/site/views/checkin/index.php
+++ b/site/views/checkin/index.php
@@ -6,7 +6,7 @@ use yii\bootstrap\Button;
  * @var yii\web\View $this
  */
 
-$this->title = "Check-In";
+$this->title = "The Faster Scale App | Check-in";
 
 function checkboxItemTemplate($index, $label, $name, $checked, $value) {
   return Html::checkbox
@@ -25,7 +25,7 @@ function checkboxItemTemplate($index, $label, $name, $checked, $value) {
     );
 }
 ?>
-<h1>Check-In</h1>
+<h1>Check-in</h1>
 <p>Click all the options below that apply to your current emotional state. Once finished, click the submit button at the bottom.</p>
 <?php
 $form = ActiveForm::begin([

--- a/site/views/checkin/questions.php
+++ b/site/views/checkin/questions.php
@@ -5,7 +5,7 @@ use yii\widgets\ActiveForm;
  * @var yii\web\View $this
  */
 
-$this->title = "Check-In | Questions";
+$this->title = "The Faster Scale App | Check-in | Questions";
 
 function radioItemTemplate($index, $label, $name, $checked, $value) {
   return Html::radio
@@ -31,7 +31,7 @@ foreach($options as $option) {
   $restructured_options[$option['category_id']][$option['user_option_id']] = $option['option_name'];
 }
 ?>
-<h1>Check-In Questions</h1>
+<h1>Check-in Questions</h1>
 <p>Answer the questions below to compete your check-in.</p>
 <p>In each category, select one feeling. Then answer the related questions.</p>
 <?php

--- a/site/views/checkin/report.php
+++ b/site/views/checkin/report.php
@@ -6,7 +6,7 @@ use yii\web\JsExpression;
  * @var yii\web\View $this
  */
 
-$this->title = "Check-in Report";
+$this->title = "The Faster Scale App | Report";
 $this->registerJsFile('/js/checkin/report.js', ['depends' => [\site\assets\AppAsset::className()]]);
 
 $pie_colors = [

--- a/site/views/checkin/view.php
+++ b/site/views/checkin/view.php
@@ -10,14 +10,14 @@ use common\components\Time;
  * @var yii\web\View $this
  */
 
-$this->title = "Past Check-ins";
+$this->title = "The Faster Scale App | Previous Check-ins";
 
 function checkboxItemTemplate($index, $label, $name, $checked, $value) {
   $checked_val = ($checked) ? "btn-primary" : "";
   return "<button class='btn btn-default $checked_val' data-toggle='button' disabled='disabled' name='$name' value='$value'>$label</button>";
 }
 ?>
-<h1>View Past Check-ins</h1>
+<h1>View Previous Check-ins</h1>
 <div id='past-checkin-nav' role='toolbar' class='btn-toolbar'>
   <div class='btn-group' role='group'>
     <a class="btn btn-default" href="<?= Url::toRoute(['checkin/view', 'date'=>Time::alterLocalDate($actual_date, "-1 week")]); ?>">&lt;&lt;</a> 

--- a/site/views/layouts/main.php
+++ b/site/views/layouts/main.php
@@ -49,8 +49,8 @@ if($hash = Utility::getRevHash()) {
                 $menuItems[] = ['label' => 'Signup', 'url' => ['/site/signup']];
                 $menuItems[] = ['label' => 'Login', 'url' => ['/site/login']];
             } else {
-                $menuItems[] = ['label' => 'Check-In', 'url' => ['/checkin/index']];
-                $menuItems[] = ['label' => 'Past Check-Ins', 'url' => ['/checkin/view']];
+                $menuItems[] = ['label' => 'Check-in', 'url' => ['/checkin/index']];
+                $menuItems[] = ['label' => 'Previous Check-ins', 'url' => ['/checkin/view']];
                 $menuItems[] = ['label' => 'Statistics', 'url' => ['/checkin/report']];
                 $menuItems[] = ['label' => Yii::$app->user->identity->username, 'url' => ['/site/profile']];
                 $menuItems[] = [

--- a/site/views/site/profile.php
+++ b/site/views/site/profile.php
@@ -46,7 +46,7 @@ $timezones = \DateTimeZone::listIdentifiers();
 
   <div class="row">
     <div class="col-md-6 col-md-push-6 bg-success">
-      <h4>Export Your Check-In Data</h4>
+      <h4>Export Your Check-in Data</h4>
       <p>To export ALL of your check-in data, click this button. You will be redirected to a CSV download that can be opened in any spreadsheet program.</p>
     
       <div class="form-group">

--- a/site/views/site/welcome.php
+++ b/site/views/site/welcome.php
@@ -13,11 +13,11 @@ $this->title = 'Welcome';
 
   <h2>Next Steps</h2>
 
-  <h3>Check-Ins</h3>
+  <h3>Check-ins</h3>
   <p>You will soon be doing a brief check-in to log and process your emotions. If you have email reports enabled and you score above your set threshold during a check-in, your selected friends will be emailed a summary of your results. This should encourage discussion and verbal processing of your thought patterns and feelings.</p>
 
   <h3>Reports</h3>
-  <p>After your check-in, you'll be redirected to your past check-in log. Here you can view the results of the check-in you just completed, as well as any you've completed in the past.</p>
+  <p>After your check-in, you'll be redirected to your previous check-in log. Here you can view the results of the check-in you just completed, as well as any you've completed in the past.</p>
   <p>Navigate into the past by clicking the arrow buttons. Additionally, a navigable calendar appears when you click on the date itself.</p>
 
   <h3>Analytics</h3>
@@ -26,7 +26,7 @@ $this->title = 'Welcome';
   <h3>Account Settings</h3>
   <p>If you need to change any of your account settings, simply go to your settings page by clicking on your username at the very top of this site. You can change email report thesholds, report partners, your password, and other goodies while there.</p>
 
-  <h3>Finally, do your first Check-In</h3>
+  <h3>Finally, do your first Check-in</h3>
     <p>Your next step should be to do a check-in. Use this button to do so:</p>
-    <a href="/checkin" class="btn btn-primary" role="button">Check-In Here!</a>
+    <a href="/checkin" class="btn btn-primary" role="button">Check-in Here!</a>
 </div>


### PR DESCRIPTION
- Prepending overlooked page titles with "The Faster Scale App | "
- Standardizing 'Check-in' term with a lowercase `i` always