### PR TITLE
Fixes #119: Enable Restoration category on Questions page

### DIFF
--- a/common/models/Question.php
+++ b/common/models/Question.php
@@ -22,10 +22,11 @@ use Yii;
 class Question extends \yii\db\ActiveRecord
 {
   public static $TYPES = [
-    1 => "a",
-    2 => "b",
-    3 => "c"
+    'a' => 1,
+    'b' => 2,
+    'c' => 3
   ];
+
   public static $QUESTIONS = [
     1 => "How does it affect me? How do I act and feel?",
     2 => "How does it affect the important people in my life?",

--- a/site/controllers/CheckinController.php
+++ b/site/controllers/CheckinController.php
@@ -67,7 +67,7 @@ class CheckinController extends \yii\web\Controller
   public function actionQuestions()
   {
     $date = Time::getLocalDate();
-    $user_options = UserOption::getUserOptionsWithCategory($date, true);
+    $user_options = UserOption::getUserOptionsWithCategory($date);
     if(count($user_options) === 0) {
       return $this->redirect(['view']);
     }

--- a/site/views/checkin/questions.php
+++ b/site/views/checkin/questions.php
@@ -8,20 +8,16 @@ use yii\widgets\ActiveForm;
 $this->title = "The Faster Scale App | Check-in | Questions";
 
 function radioItemTemplate($index, $label, $name, $checked, $value) {
-  return Html::radio
-    (
-      $name,
-      $checked,
-      [
-        'value' => $value,
-        'label' => $label,
-        'container' => false,
-        'labelOptions' =>
-        [
-          'class' => $checked ? 'btn btn-info active' : 'btn btn-info',
-        ],
-      ]
-    );
+  return Html::radio(
+    $name,
+    $checked,
+    ['value' => $value,
+     'label' => $label,
+     'container' => false,
+     'labelOptions' => [ 'class' => $checked
+                                     ? 'btn btn-info active'
+                                     : 'btn btn-info'],
+    ]);
 }
 
 $categories = [];


### PR DESCRIPTION
A user suggested we allow the user to answer processing questions for
behaviors in the Restoration category. This allows users to process and
reflect on positive behaviors and experiences -- which is a good thing.