### PR TITLE
Improving messaging on email verification error

### DIFF
--- a/site/controllers/SiteController.php
+++ b/site/controllers/SiteController.php
@@ -189,7 +189,7 @@ class SiteController extends Controller
 
     $user = User::findByVerifyEmailToken($token);
     if (!$user) {
-      throw new BadRequestHttpException('Wrong or expired email verification token.');
+      throw new BadRequestHttpException("Wrong or expired email verification token. If you aren't sure why this error occurs perhaps you've already verified your account. Please try logging in.");
     }
 
     if (Yii::$app->getUser()->login($user)) {


### PR DESCRIPTION
Often new users get confused when verifying their account and click the verification link multiple times. Subsequent attempts throw a 400 error. This improves the messaging and should help clear up their confusion.