### PR TITLE
Fixing email verification process

### DIFF
--- a/common/models/LoginForm.php
+++ b/common/models/LoginForm.php
@@ -53,8 +53,9 @@ class LoginForm extends Model
   public function login()
   {
     if($this->validate()) {
-      if($this->getUser()->isVerified()) {
-        return Yii::$app->user->login($this->getUser(), $this->rememberMe ? 3600 * 24 * 30 : 0);
+      $user = $this->getUser();
+      if($user->isVerified()) {
+        return Yii::$app->user->login($user, $this->rememberMe ? 3600 * 24 * 30 : 0);
       } else {
         Yii::$app->getSession()->setFlash('warning', 'You must verify your account before you can proceed. Please check your email inbox for a verification email and follow the instructions.');
       }

--- a/common/tests/unit/models/UserTest.php
+++ b/common/tests/unit/models/UserTest.php
@@ -763,12 +763,24 @@ public $userOptions = [
     });
   }
 
+  public function testIsTokenConfirmed() {
+      expect('isTokenConfirmed should return true if the token has been confirmed', $this->assertTrue($this->user->isTokenConfirmed('token123_confirmed')));
+      expect('isTokenConfirmed should return false if the token has not been confirmed', $this->assertFalse($this->user->isTokenConfirmed('token123')));
+      expect('isTokenConfirmed should return false if the token has not been confirmed', $this->assertFalse($this->user->isTokenConfirmed('token123_not_blah')));
+  }
+
+  public function testConfirmVerifyEmailToken() {
+    $this->user->verify_email_token = 'hello_world';
+    $this->user->confirmVerifyEmailToken();
+    expect('confirmVerifyEmailToken should append User::CONFIRMED_STRING to the end of the verify_email_token property', $this->assertEquals($this->user->verify_email_token, 'hello_world'.User::CONFIRMED_STRING));
+  }
+
   public function testIsVerified() {
     $this->specify('isTokenCurrent should function correctly', function () {
       $this->user->verify_email_token = null;
       expect('isVerified should return true if the token is null', $this->assertTrue($this->user->isVerified()));
       $this->user->verify_email_token = '';
-      expect('isVerified should return true if the token is the empty string', $this->assertTrue($this->user->isVerified()));
+      expect('isVerified should return false if the token is the empty string', $this->assertFalse($this->user->isVerified()));
       $this->user->verify_email_token = 'this_looks_truthy';
       expect('isVerified should return false if the token is still present', $this->assertFalse($this->user->isVerified()));
     });

--- a/site/controllers/SiteController.php
+++ b/site/controllers/SiteController.php
@@ -202,8 +202,11 @@ class SiteController extends Controller
       throw new BadRequestHttpException("Wrong or expired email verification token. If you aren't sure why this error occurs perhaps you've already verified your account. Please try logging in.");
     }
 
-    if (Yii::$app->getUser()->login($user)) {
-      $user->removeVerifyEmailToken();
+    if($user->isTokenConfirmed($user->verify_email_token)) {
+      Yii::$app->getSession()->setFlash('success', 'Your account has already been verified. Please log in.');
+      return $this->redirect('/login',302);
+    } else if (Yii::$app->getUser()->login($user)) {
+      $user->confirmVerifyEmailToken();
       $user->save();
       Yii::$app->getSession()->setFlash('success', 'Your account has been verified. Please continue with your check-in.');
       return $this->redirect('/welcome',302);


### PR DESCRIPTION
A number of new users have had issues verifying their account. This should make the process more straightforward and more easily understandable.

Now, when a user clicks on the verification link multiple times it redirects them to the /login page and displays a flash message telling them they've already verified their account. This is far better than throwing a 400 exception 😄 