### PR TITLE
Switching back data export date format to 'YYYY-MM-DD HH:MM:SS'

### DIFF
--- a/common/components/Time.php
+++ b/common/components/Time.php
@@ -23,7 +23,7 @@ class Time extends \yii\base\Object implements \common\interfaces\TimeInterface 
   }
 
   public function convertUTCToLocal($utc, $iso = true) {
-    $fmt = $iso ? Datetime::ATOM : "Y-m-d";
+    $fmt = $iso ? Datetime::ATOM : "Y-m-d H:i:s";
 
     $timestamp = new DateTime($utc, new DateTimeZone("UTC"));
     $timestamp->setTimeZone(new DateTimeZone($this->timezone));

--- a/common/models/User.php
+++ b/common/models/User.php
@@ -373,8 +373,10 @@ class User extends ActiveRecord implements IdentityInterface, UserInterface
           "question2",
           "question3"')
       ->orderBy('l.date DESC');
-   $data = $this->user_option::decorateWithCategory($query->all());
-   return $this->cleanExportData($data);
+
+    return $query
+      ->createCommand()
+      ->query();
 
 /* Plaintext Query
 SELECT l.id,
@@ -554,7 +556,7 @@ ORDER  BY l.date DESC;
    $ret = array_map(
      function($row) use ($order) {
        // change timestamp to local time (for the user)
-       $row['date'] = $this->time->convertUTCToLocal($row['date']);
+       $row['date'] = $this->time->convertUTCToLocal($row['date'], false);
        
        // clean up things we don't need
        $row['category'] = $row['option']['category']['name'];

--- a/common/tests/unit/components/TimeTest.php
+++ b/common/tests/unit/components/TimeTest.php
@@ -81,7 +81,7 @@ class TimeTest extends \Codeception\Test\Unit
         $utc_tz = (new DateTime("now"))->format("Y-m-d H:i:s");
 
         expect('convertUTCToLocal should convert a UTC tz to Los Angeles with the included timezone', $this->assertEquals((new DateTime("now", new DateTimeZone("America/Los_Angeles")))->format(DateTime::ATOM), $this->time->convertUTCToLocal($utc_tz)));
-        expect('convertUTCToLocal should convert a UTC tz to Los Angeles without the included timezone', $this->assertEquals($this->time->convertUTCToLocal($utc_tz, false), (new DateTime("now", new DateTimeZone("America/Los_Angeles")))->format("Y-m-d")));
+        expect('convertUTCToLocal should convert a UTC tz to Los Angeles without the included timezone', $this->assertEquals($this->time->convertUTCToLocal($utc_tz, false), (new DateTime("now", new DateTimeZone("America/Los_Angeles")))->format("Y-m-d H:i:s")));
 
         // with UTC
         $this->container->set('common\interfaces\TimeInterface', function () {

--- a/common/tests/unit/models/UserTest.php
+++ b/common/tests/unit/models/UserTest.php
@@ -894,28 +894,28 @@ public $exportData = [
 
     expect('cleanExportData should clean and mutate the queried data to be suitable for downloading', $this->assertEquals([
       [
-        'date' => '2017-07-29T03:40:29-07:00',
+        'date' => '2017-07-29 03:40:29',
         'option' => 'repetitive, negative thoughts',
         'category' => 'Speeding Up',
         'question1' => 'q1',
         'question2' => 'q2',
         'question3' => 'q3',
       ], [
-        'date' => '2017-07-29T03:40:29-07:00',
+        'date' => '2017-07-29 03:40:29',
         'option' => 'tired',
         'category' => 'Exhausted',
         'question1' => 'q1',
         'question2' => 'q2',
         'question3' => 'q3',
       ], [
-        'date' => '2017-07-29T03:40:29-07:00',
+        'date' => '2017-07-29 03:40:29',
         'option' => 'out of control',
         'category' => 'Relapse/Moral Failure',
         'question1' => 'q1',
         'question2' => 'q2',
         'question3' => 'q3',
       ], [
-        'date' => '2017-07-29T03:40:29-07:00',
+        'date' => '2017-07-29 03:40:29',
         'option' => 'obsessive (stuck) thoughts',
         'category' => 'Ticked Off',
         'question1' => 'q1',

--- a/site/controllers/SiteController.php
+++ b/site/controllers/SiteController.php
@@ -271,7 +271,7 @@ class SiteController extends Controller
     header("Content-Type: text/csv");
     header("Content-Disposition: attachment; filename=fsa-data-export-".Yii::$app->user->identity->email."-".date('Ymd').".csv");
 
-    $data = Yii::$app->user->identity->getExportData();
+    $reader = Yii::$app->user->identity->getExportData();
     $fp = fopen('php://output', 'w');
 
     $header = [
@@ -284,8 +284,11 @@ class SiteController extends Controller
     ];
 
     fputcsv($fp, $header);
-    foreach($data as $row) {
-      fputcsv($fp, $row);
+    while($row = $reader->read()) {
+      // SWAP THIS OUT FOR DI WHEN improve-score-formula branch is merged
+      $row = \common\models\UserOption::decorateWithCategory([$row]);
+      $row = Yii::$app->user->identity->cleanExportData($row);
+      fputcsv($fp, $row[0]);
     }
     fclose($fp);
 


### PR DESCRIPTION
A user reported that Excel does not automatically recognize dates in
ISO8601 format, so we're switching them back to the old way.

Also took this opportunity to improve the streaming of this export.