### PR TITLE
Improves change password mechanism. Restyles /profile page.

### DIFF
--- a/site/assets/css/app.scss
+++ b/site/assets/css/app.scss
@@ -93,10 +93,6 @@ body {
   font-height: inherit;
 }
 
-#profile-button {
-  width: 100px;
-}
-
 .indent {
   margin-left: 10px;
 }
@@ -128,6 +124,28 @@ body {
     }
     .post-body {
       padding-left: 25px;
+    }
+  }
+}
+
+.card {
+  margin-bottom: 30px;
+  min-width: 0;
+  word-wrap: break-word;
+  background-clip: border-box;
+  border: 1px solid rgba(0,0,0,.125);
+  border-radius: .25rem;
+
+  .card-header {
+    padding: .75rem 1.25rem;
+    margin-bottom: 0;
+    background-color: #f7f7f9;
+    border-bottom: 1px solid rgba(0,0,0,.125);
+  }
+  .card-body, .card-block {
+    padding: 1.25rem;
+    .card-title {
+      margin-bottom: .75rem;
     }
   }
 }

--- a/site/models/ChangePasswordForm.php
+++ b/site/models/ChangePasswordForm.php
@@ -1,0 +1,71 @@
+<?php
+namespace site\models;
+
+use common\models\User;
+use yii\base\Model;
+use Yii;
+
+/**
+ * change password form
+ */
+class ChangePasswordForm extends Model
+{
+  public $old_password;
+  public $new_password;
+  private $user;
+
+  /**
+   * Creates a form model
+   *
+   * @param  object                          $user
+   * @param  array                           $config name-value pairs that will be used to initialize the object properties
+   */
+  public function __construct(\common\interfaces\UserInterface $user, $config = []) {
+    $this->user = $user;
+    parent::__construct($config);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function rules()
+  {
+    return [
+      ['old_password', 'string', 'min' => 6],
+      ['new_password', 'string', 'min' => 8],
+      [['old_password', 'new_password'], 'required'],
+      ['old_password', 'validatePassword'],
+    ];
+  }
+
+  public function attributeLabels() {
+    return [
+      'old_password' => 'Current Password',
+      'new_password' => 'New Password',
+      ];
+  }
+
+  /**
+   * Validates the password.
+   * This method serves as the inline validation for password.
+   */
+  public function validatePassword()
+  {
+    if (!$this->hasErrors()) {
+      if (!$this->user->validatePassword($this->old_password)) {
+        $this->addError('old_password', 'Incorrect email or password.');
+      }
+    }
+  }
+
+  /**
+   * changes user's password.
+   *
+   * @return Boolean whether or not the save was successful
+   */
+  public function changePassword()
+  {
+    $this->user->setPassword($this->new_password);
+    return $this->user->save();
+  }
+}

--- a/site/models/EditProfileForm.php
+++ b/site/models/EditProfileForm.php
@@ -11,7 +11,6 @@ use \DateTimeZone;
 class EditProfileForm extends Model
 {
   public $email;
-  public $password;
   public $timezone;
   public $send_email;
   public $email_threshold;
@@ -44,7 +43,6 @@ class EditProfileForm extends Model
       ['email', 'email'],
       ['email', 'unique', 'targetClass' => '\common\models\User', 'message' => 'This email address has already been taken.', 'filter' => "id <> ".Yii::$app->user->id],
 
-      ['password', 'string', 'min' => 6],
 
       ['timezone', 'string', 'min' => 2, 'max' => 255],
       ['timezone', 'in', 'range'=>DateTimeZone::listIdentifiers()],
@@ -82,12 +80,10 @@ class EditProfileForm extends Model
   public function saveProfile()
   {
     if ($this->validate()) {
-      $user = $this->user->findOne(Yii::$app->user->id);
+      $user = $this->user;
 
       if($this->email)
         $user->email = $this->email;
-      if($this->password)
-        $user->setPassword($this->password);
       if($this->timezone)
         $user->timezone = $this->timezone;
       if($this->send_email) {
@@ -110,7 +106,7 @@ class EditProfileForm extends Model
   }
 
   public function loadUser() {
-    $user                  = $this->user->findOne(Yii::$app->user->id);
+    $user                  = $this->user;
     $this->email           = $user->email;
     $this->timezone        = $user->timezone;
     $this->email_threshold = $user->email_threshold;

--- a/site/models/SignupForm.php
+++ b/site/models/SignupForm.php
@@ -39,7 +39,7 @@ class SignupForm extends Model
       ['email', 'email'],
 
       ['password', 'required'],
-      ['password', 'string', 'min' => 6],
+      ['password', 'string', 'min' => 8],
 
       ['timezone', 'required'],
       ['timezone', 'string', 'min' => 2, 'max' => 255],

--- a/site/tests/_support/MockUser.php
+++ b/site/tests/_support/MockUser.php
@@ -3,12 +3,15 @@
 namespace site\tests\_support;
 class MockUser implements \common\interfaces\UserInterface, \yii\web\IdentityInterface {
   public $timezone = 'America/Los_Angeles';
+  public $password;
 
  public static function findIdentity($id) {}
  public static function findIdentityByAccessToken($token, $type = null) {}
  public function getId() {}
  public function getAuthKey() {}
  public function validateAuthKey($authKey) {}
+ public function validatePassword($password) {}
+ public function setPassword($password) {}
 
   public static function primaryKey() {}
   public function attributes() {}

--- a/site/tests/unit/models/ChangePasswordFormTest.php
+++ b/site/tests/unit/models/ChangePasswordFormTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace site\tests\unit\models;
+
+use Yii;
+
+class ChangePasswordFormTest extends \Codeception\Test\Unit
+{
+  use \Codeception\Specify;
+
+  private $user;
+
+  public function setUp() {
+    $this->container = new \yii\di\Container;
+    $this->user = $this->getMockBuilder('\site\tests\_support\MockUser')
+      ->setMethods(['validatePassword', 'setPassword', 'save'])
+      ->getMock();
+    parent::setUp();
+  }
+
+  public function tearDown() {
+    $this->user = null;
+    parent::tearDown();
+  }
+
+  public function testSimpleRulesShouldValidate() {
+    $user = $this->user;
+    $this->container = new \yii\di\Container;
+    $form = $this->container->get('\site\models\ChangePasswordForm', [$user]);
+
+    $form->attributes = [];
+    expect('with no values, the form should not pass validation', $this->assertFalse($form->validate()));
+    $form->attributes = ['old_password' => '12345678'];
+    expect('with one value, the form should not pass validation', $this->assertFalse($form->validate()));
+    $form->attributes = ['new_password' => '12345678'];
+    expect('with one value, the form should not pass validation', $this->assertFalse($form->validate()));
+
+    $user
+      ->expects($this->never())
+      ->method('validatePassword');
+    $form->attributes = [
+      'old_password' => '123456',
+      'new_password' => '789012',
+    ];
+    expect('with a new password of < 8 chars, the form should not pass validation', $this->assertFalse($form->validate()));
+  }
+
+  public function testValidatePasswordShouldFailWithABadPassword() {
+    $user = $this->user;
+
+    $old = 'not_my_current_pass';
+    $user
+      ->expects($this->once())
+      ->method('validatePassword')
+      ->with($this->equalTo($old));
+    $user
+      ->method('validatePassword')
+      ->willReturn(false);
+
+    $form = $this->container->get('\site\models\ChangePasswordForm', [$user]);
+    $form->attributes = [
+      'old_password' => $old,
+      'new_password' => 'my_desired_Pass',
+    ];
+    expect('a failed password should not pass validation', $this->assertFalse($form->validate()));
+    expect('a failed password should add an error fail validation', $this->assertGreaterThan(0, count($form->errors)));
+  }
+
+  public function testValidatePasswordShouldPassWithAGoodPassword() {
+    $user = $this->user;
+    $old = 'my_current_pass';
+
+    $user
+      ->method('validatePassword')
+      ->willReturn(true);
+    $user
+      ->expects($this->once())
+      ->method('validatePassword')
+      ->with($this->equalTo($old));
+
+    $form = $this->container->get('\site\models\ChangePasswordForm', [$user]);
+    $form->attributes = [
+      'old_password' => $old,
+      'new_password' => 'my_desired_Pass',
+    ];
+    expect('a good password should pass validation', $this->assertTrue($form->validate()));
+    expect('a good password should not add any errors', $this->assertEquals(0, count($form->errors)));
+  }
+
+  public function testChangePassword() {
+    $user = $this->user;
+    $old = 'my_current_pass';
+    $new = 'my_desired_Pass';
+
+    $user
+      ->method('save')
+      ->willReturn(true);
+    $user
+      ->expects($this->once())
+      ->method('setPassword')
+      ->with($this->equalTo($new));
+
+    $form = $this->container->get('\site\models\ChangePasswordForm', [$user]);
+    $form->attributes = [
+      'old_password' => $old,
+      'new_password' => $new,
+    ];
+    expect('changePassword should return true if save returns true', $this->assertTrue($form->changePassword()));
+  }
+}

--- a/site/tests/unit/models/CheckinFormTest.php
+++ b/site/tests/unit/models/CheckinFormTest.php
@@ -105,23 +105,15 @@ class CheckinFormTest extends \Codeception\Test\Unit
 				],
 			],
 		];
- 
 
     protected function setUp() {
       $this->container = new \yii\di\Container;
-      $this->container->set('common\interfaces\UserInterface', '\site\tests\_support\MockUser');
       $this->container->set('common\interfaces\UserOptionInterface', '\site\tests\_support\MockUserOption');
-      $this->container->set('common\interfaces\QuestionInterface', '\site\tests\_support\MockQuestion');
     $this->container->set('common\interfaces\TimeInterface', function () {
       return new \common\components\Time('America/Los_Angeles');
     });
       parent::setUp();
     }
-
-    //protected function tearDown()
-    //{
-        //parent::tearDown();
-    //}
 
 		public function testAttributeLabels()
 		{

--- a/site/views/site/profile.php
+++ b/site/views/site/profile.php
@@ -9,20 +9,21 @@ $timezones = \DateTimeZone::listIdentifiers();
 <div class="site-profile">
   <h1><?= Html::encode($this->title) ?></h1>
 
-  <p>Edit your account information below:</p>
+  <p>Update your account information below</p>
 
   <div class="row">
-    <div class="col-md-6">
-			<?php $form = ActiveForm::begin([
-				'id' => 'form-profile',
-				'enableClientValidation' => true,
-				'options' => ['validateOnSubmit' => true]
-			]); ?>
-        <?= $form->field($profile, 'email', ['inputTemplate' => '<div class="input-group"><span class="input-group-addon">@</span>{input}</div>']); ?>
-        <?= $form->field($profile, 'password')->passwordInput() ?>
-		    <?= $form->field($profile, 'timezone')->dropDownList(array_combine($timezones, $timezones)); ?>
-    </div>
-    <div class="col-md-6">
+    <div class="col-md-4">
+      <div class="card">
+        <div class="card-header"><h4>Update profile</h4></div>
+        <div class="card-block">
+          <div class="card-text">
+  <?php $form = ActiveForm::begin([
+    'id' => 'form-profile',
+    'enableClientValidation' => true,
+    'options' => ['validateOnSubmit' => true]
+  ]); ?>
+          <?= $form->field($profile, 'email', ['inputTemplate' => '<div class="input-group"><span class="input-group-addon">@</span>{input}</div>']); ?>
+          <?= $form->field($profile, 'timezone')->dropDownList(array_combine($timezones, $timezones)); ?>
         <?= $form->field($profile, 'send_email')->checkbox() ?>
         <div id='email_threshold_fields' <?php if(!$profile->send_email) { ?>style="display: none;"<?php } ?>>
           <?= $form->field($profile, 'email_threshold')->textInput(['class'=>'form-control', 'style'=>'width: 50px;'])->input('number', ['min' => 0, 'max' => 1000]) ?>
@@ -30,50 +31,89 @@ $timezones = \DateTimeZone::listIdentifiers();
           <?= $form->field($profile, 'partner_email2')->input('email'); ?>
           <?= $form->field($profile, 'partner_email3')->input('email'); ?>
         </div>
+        <?= Html::submitButton('Update', ['class' => 'btn btn-primary', 'id' => 'profile-button', 'name' => 'profile-button']) ?>
+        <?php ActiveForm::end(); ?>
+    </div>
     </div>
   </div>
-  <div class="row">
-    <div class="col-md-2 col-xs-2">
-      <div class="form-group">
-        <?= Html::submitButton('Save', ['class' => 'btn btn-primary', 'id' => 'profile-button', 'name' => 'profile-button']) ?>
+  </div>
+
+    <div class="col-md-4">
+      <div class="card">
+      <div class="card-header"><h4>Change password</h4></div>
+      <div class="card-block">
+        <div class="card-text">
+          <?php $form = ActiveForm::begin([
+            'id' => 'form-change-password',
+            'action' => ['site/change-password'],
+            'method' => 'post',
+            'enableClientValidation' => true,
+            'options' => ['validateOnSubmit' => true]
+          ]); ?>
+          <?= $form->field($change_password, 'old_password')->passwordInput() ?>
+          <?= $form->field($change_password, 'new_password', ['inputTemplate' => '<div class="input-group">{input}<span class="input-group-btn"><button id="new-password-toggle" class="btn btn-default" type="button">Show</button></span></div>'])->passwordInput() ?>
+          <div class="form-group">
+          <?= Html::submitButton('Change', ['class' => 'btn btn-warning', 'name' => 'change-password-button']) ?>
+          </div>
+          <?php ActiveForm::end(); ?>
+        </div>
+      </div>
       </div>
     </div>
-  </div>
-  <?php ActiveForm::end(); ?>
-
-  <hr />
-
-  <div class="row">
-    <div class="col-md-6 col-md-push-6 bg-success">
-      <h4>Export Your Check-in Data</h4>
-      <p>To export ALL of your check-in data, click this button. You will be redirected to a CSV download that can be opened in any spreadsheet program.</p>
+    <div class="col-md-4">
+      <div class="card">
+          <div class="card-header"><h4>Export Check-in Data</h4></div>
+        <div class="card-block">
+          <div class="card-text">
+            <p>To export ALL of your check-in data, click this button. You will be redirected to a CSV download that can be opened in any spreadsheet program.</p>
     
-      <div class="form-group">
-        <?= Html::a('Export', ['/site/export'], ['class'=>'btn btn-success']) ?>
+            <div class="form-group">
+              <?= Html::a('Export', ['/site/export'], ['class'=>'btn btn-success']) ?>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card-header"><h4>Delete account</h4></div>
+        <div class="card-block">
+          <div class="card-text">
+            <p>If you're really <em>really</em> sure about this, please enter your password below and click the Delete button. You will be logged out, your account and all your stored data will be immediately deleted, and a notification email will be sent to you and your partners.</p>
+        <?php $form = ActiveForm::begin([
+          'id' => 'form-delete-account',
+          'action' => ['site/delete-account'],
+          'method' => 'post',
+          'enableClientValidation' => true,
+          'options' => ['validateOnSubmit' => true]
+        ]); ?>
+            <?= $form->field($delete, 'password')->passwordInput() ?>
+            <div class="form-group">
+            <?= Html::submitButton('Delete', ['class' => 'btn btn-danger', 'name' => 'delete-account-button']) ?>
+            </div>
+            <?php ActiveForm::end(); ?>
+          </div>
+        </div>
       </div>
     </div>
+  </div>
 
-    <div class="col-md-6 bg-danger col-md-pull-6">
-    <h4>Delete your account?</h4>
-    <p>Aww shucks, we're sorry to see you go! If you're really sure about this, please enter your password below and click the Delete button. Your account and all your stored data will be deleted, and a notification email will be sent to you and your partners.</p>
-<?php $form = ActiveForm::begin([
-  'id' => 'form-delete-account',
-  'action' => ['site/delete-account'],
-  'method' => 'post',
-  'enableClientValidation' => true,
-  'options' => ['validateOnSubmit' => true]
-]); ?>
-    <?= $form->field($delete, 'password')->passwordInput() ?>
-    <div class="form-group">
-    <?= Html::submitButton('Delete', ['class' => 'btn btn-danger', 'name' => 'delete-account-button']) ?>
-    </div>
-    <?php ActiveForm::end(); ?>
+  <div class="row">
+    <div class="col-md-4">
     </div>
   </div>
 </div>
 
 <?php $this->registerJs(
-  "$('#editprofileform-send_email').click(function() {
+  "$('#new-password-toggle').click(function () {
+    if( $('#changepasswordform-new_password').attr('type') === 'password' ) {
+      $('#new-password-toggle').text('Hide');
+      $('#changepasswordform-new_password').attr('type', 'text');
+    } else {
+      $('#new-password-toggle').text('Show');
+      $('#changepasswordform-new_password').attr('type', 'password');
+    }
+  });
+
+  $('#editprofileform-send_email').click(function() {
     $('#email_threshold_fields').toggle();
   });"
 );


### PR DESCRIPTION
- This switches the /profile page to a "card" style layout. It looks
much nicer
- Now, the user must supply their current password to change it
- When loading & saving the /profile page, data is pulled out of the
session instead of the database. This results in a immediate (and
visual) update to the data when saved. Previously (for example), if the
user's email was updated the header would still show the old email until
the next page turn. This has been fixed.