### PR TITLE
Fixes a race condition in the signup form

### DIFF
--- a/site/views/site/signup.php
+++ b/site/views/site/signup.php
@@ -15,6 +15,7 @@ $this->registerMetaTag([
   'name' => 'description',
   'content' => 'Sign up here for the Faster Scale App, the online version of the popular emotional mindfulness questionnaire. Sign up is easy and always completely free!'
 ]);
+$this->registerJsFile('/js/site/signup.js', ['depends' => [\site\assets\AppAsset::className()]]);
 ?>
 <div class="site-signup">
   <h1>Signup</h1>
@@ -32,7 +33,7 @@ $this->registerMetaTag([
         <?= $form->field($model, 'captcha')->widget(Captcha::className(), [
           'template' => '<div class="row"><div class="col-md-5">{image}</div><div class="col-md-6 col-md-offset-1">{input}</div></div>',
         ]) ?>
-        <?= $form->field($model, 'send_email')->checkbox() ?>
+        <?= $form->field($model, 'send_email')->checkbox(['disabled'=>true]) ?>
         <div id='email_threshold_fields' <?php if(!$model->send_email) { ?>style="display: none;"<?php } ?>>
           <?= $form->field($model, 'email_threshold', ['template' => '{label}<div class="row"><div class="col-md-3">{input}</div><div class="col-md-9"><p class="bg-info text-center" style="margin: 5px 0px;">We recommend starting with 30</p></div></div>{error}'])->textInput(['class'=>'form-control'])->input('number', ['min' => 0, 'max' => 100]) ?>
           <?= $form->field($model, 'partner_email1')->input('email') ?>

--- a/site/web/js/site/signup.js
+++ b/site/web/js/site/signup.js
@@ -1,0 +1,12 @@
+(function($) {
+  $(document).ready(function() {
+    $('#signupform-send_email').removeAttr('disabled');
+    $('#signupform-send_email').click(function() {
+      if($(this).is(":checked")) {
+        $('#email_threshold_fields').show();
+      } else {
+        $('#email_threshold_fields').hide();
+      }
+    });
+  });
+})(jQuery)


### PR DESCRIPTION
The 'Send an email' button could be clicked before jQuery had fully
loaded and then would NOT display the extra form. This disables the
checkbox until jQuery has fully loaded and document.ready() has fired.