### PR TITLE
On CSRF error, displays a flash message on originating page

### DIFF
--- a/common/components/Controller.php
+++ b/common/components/Controller.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace common\components;
+
+use Yii;
+
+class Controller extends \yii\web\Controller {
+  /**
+   * {@inheritdoc}
+   */
+  public function beforeAction($action)
+  {
+    if ($this->enableCsrfValidation
+      && Yii::$app->getErrorHandler()->exception === null
+      && !Yii::$app->getRequest()->validateCsrfToken()) {
+
+      Yii::$app->session->setFlash('error', 'Your security token has expired. Please retry your submission.');
+      $this->redirect(Yii::$app->request->referrer ?: Yii::$app->homeUrl);
+      return false;
+    }
+
+    return parent::beforeAction($action);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function actions()
+  {
+    return [
+      'error' => [
+         'class' => 'yii\web\ErrorAction',
+       ],
+      'captcha' => [
+        'class' => 'yii\captcha\CaptchaAction',
+      ],
+    ];
+  }
+}

--- a/common/components/View.php
+++ b/common/components/View.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace site\classes;
+namespace common\components;
 
 use yii\helpers\Html;
 
@@ -12,7 +12,8 @@ class View extends \yii\web\View {
      */
     public $json;
 
-  public function registerJson($array, $key = null, $options = 0, $depth = 512)
+  // this is the key new function here
+  public function registerJson(array $array, $key = null, $options = 0, $depth = 512)
   {
     $json = json_encode($array, $options, $depth);
     $key = $key ?: md5($json);

--- a/common/config/test.php
+++ b/common/config/test.php
@@ -14,5 +14,8 @@ return [
       'viewPath' => '@common/mail',
       'useFileTransport' => true,
     ],
+    'request' => [
+      'class' => \common\tests\_support\MockRequest::class
+    ]
   ]
 ];

--- a/common/models/LoginForm.php
+++ b/common/models/LoginForm.php
@@ -65,7 +65,7 @@ class LoginForm extends Model
       if($user->isVerified()) {
         return Yii::$app->user->login($user, $this->rememberMe ? 3600 * 24 * 30 : 0);
       } else {
-        Yii::$app->getSession()->setFlash('warning', 'You must verify your account before you can proceed. Please check your email inbox for a verification email and follow the instructions.');
+        Yii::$app->session->setFlash('warning', 'You must verify your account before you can proceed. Please check your email inbox for a verification email and follow the instructions.');
       }
     }
     return false;

--- a/common/tests/_support/MockRequest.php
+++ b/common/tests/_support/MockRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace common\tests\_support;
+class MockRequest extends \yii\web\Request {
+
+  public $csrfValidationReturn = true;
+
+
+  public function setCsrfToken($token) {
+    $this->_csrfToken = $token;
+  }
+
+  public function validateCsrfToken($clientSuppliedToken = null) {
+    return $this->csrfValidationReturn;
+  }
+}

--- a/common/tests/unit/components/ControllerTest.php
+++ b/common/tests/unit/components/ControllerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace common\tests\unit\components;
+
+use Yii;
+use common\components\Controller;
+
+/**
+ * Controller test
+ */
+
+class ControllerTest extends \Codeception\Test\Unit {
+    use \Codeception\Specify;
+
+    public function testActions() {
+      $controller = new Controller('test', 'common');
+      expect('actions should return an array of action settings', $this->assertEquals([
+        'error' => [
+          'class' => 'yii\web\ErrorAction',
+        ],
+        'captcha' => [
+          'class' => 'yii\captcha\CaptchaAction',
+        ],
+      ], $controller->actions()));
+    }
+
+    public function testBeforeAction() {
+      $controller = new Controller('test', 'common');
+      $controller->enableCsrfValidation = true;
+
+      expect("If CSRF token is valid and parent's beforeAction() returns true, return true", $this->assertTrue($controller->beforeAction('test')));
+
+      // this is a terrible way to test this
+      // look in common/config/test.php, we are setting the request class to be
+      // \common\tests\_support\MockRequest
+      Yii::$app->getRequest()->csrfValidationReturn = false;
+      expect("If CSRF token is NOT valid and parent's beforeAction() returns true, return false", $this->assertFalse($controller->beforeAction('test')));
+
+    }
+}

--- a/common/tests/unit/components/ViewTest.php
+++ b/common/tests/unit/components/ViewTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace common\tests\unit\components;
+
+use Yii;
+use common\components\View;
+
+/**
+ * View test
+ */
+
+class ViewTest extends \Codeception\Test\Unit {
+    use \Codeception\Specify;
+
+    public function testRegisterJson() {
+      $view = new View();
+      $key = 'test';
+      $data = [
+        'name' => 'user one',
+        'email' => 'userone@example.com'
+      ];
+      $view->registerJson($data, $key);
+
+      expect("The supplied array should be encoded as JSON and set on the View obj", $this->assertEquals($data, json_decode($view->json[$view::POS_READY][$key], true)));
+
+      $view = new View();
+      $data = [
+        'name' => 'user one',
+        'email' => 'userone@example.com'
+      ];
+      $view->registerJson($data);
+
+      $expected_key = md5(json_encode($data, true));
+      expect("If no key is supplied it should default to the md5 of the json_encoded data", $this->assertArrayHasKey($expected_key, $view->json[$view::POS_READY]));
+      expect("If no key is supplied it should default to the md5 of the json_encoded data", $this->assertEquals(json_encode($data, true), $view->json[$view::POS_READY][$expected_key]));
+    }
+}

--- a/common/tests/unit/models/LoginFormTest.php
+++ b/common/tests/unit/models/LoginFormTest.php
@@ -114,7 +114,7 @@ class LoginFormTest extends \Codeception\Test\Unit {
       $this->form->password = 'hunter2';
 
       expect('login should return false if account is not verified', $this->assertFalse($this->form->login()));
-      expect('login should set a flash message if account is not verified', $this->assertNotEmpty(Yii::$app->getSession()->getFlash('warning', null, true)));
+      expect('login should set a flash message if account is not verified', $this->assertNotEmpty(Yii::$app->session->getFlash('warning', null, true)));
     });
 
     $this->specify('login should fail if credentials are not valid', function() {
@@ -123,7 +123,7 @@ class LoginFormTest extends \Codeception\Test\Unit {
       $this->form->email = 'hunter2@hunter2.com';
       $this->form->password = 'hunter2';
       expect('login should return false credentials are bad', $this->assertFalse($this->form->login()));
-      expect('login should NOT set a flash message if credentials are bad', $this->assertEmpty(Yii::$app->getSession()->getFlash('warning', null, true)));
+      expect('login should NOT set a flash message if credentials are bad', $this->assertEmpty(Yii::$app->session->getFlash('warning', null, true)));
     });
   }
 }

--- a/site/config/main.php
+++ b/site/config/main.php
@@ -63,7 +63,7 @@ return [
       ],
     ],
     'view' => [
-      'class' => site\classes\View::class
+      'class' => common\components\View::class
     ]
   ],
   'params' => $params,

--- a/site/controllers/CheckinController.php
+++ b/site/controllers/CheckinController.php
@@ -11,12 +11,12 @@ use common\interfaces\TimeInterface;
 use yii\di\Container;
 use yii\base\InvalidParamException;
 use yii\web\BadRequestHttpException;
-use yii\web\Controller;
+use common\components\Controller;
 use yii\filters\VerbFilter;
 use common\components\AccessControl;
 use yii\helpers\ArrayHelper as AH;
 
-class CheckinController extends \yii\web\Controller
+class CheckinController extends Controller
 {
   public function behaviors()
   {

--- a/site/controllers/ProfileController.php
+++ b/site/controllers/ProfileController.php
@@ -4,7 +4,7 @@ namespace site\controllers;
 
 use Yii;
 use common\models\Question;
-use yii\web\Controller;
+use common\components\Controller;
 use yii\filters\VerbFilter;
 use common\components\AccessControl;
 use League\Csv\Writer;
@@ -42,21 +42,6 @@ class ProfileController extends Controller {
     ];
   }
 
-  /**
-   * @inheritdoc
-   */
-  public function actions()
-  {
-    return [
-      'error' => [
-        'class' => 'yii\web\ErrorAction',
-      ],
-      'captcha' => [
-        'class' => 'yii\captcha\CaptchaAction',
-      ],
-    ];
-  }
-
   public function actionIndex() {
     $editProfileForm    = Yii::$container->get(\site\models\EditProfileForm::class, [Yii::$app->user->identity]);
     $changePasswordForm = Yii::$container->get(\site\models\ChangePasswordForm::class, [Yii::$app->user->identity]);
@@ -73,7 +58,7 @@ class ProfileController extends Controller {
     if ($editProfileForm->load(Yii::$app->request->post())) {
       $saved_user = $editProfileForm->saveProfile();
       if($saved_user) {
-        Yii::$app->getSession()->setFlash('success', 'New profile data saved!');
+        Yii::$app->session->setFlash('success', 'New profile data saved!');
       }
     }
 
@@ -93,7 +78,7 @@ class ProfileController extends Controller {
       if($model->deleteAccount()) {
         $this->redirect(['site/index']);
       } else {
-        Yii::$app->getSession()->setFlash('error', 'Wrong password!');
+        Yii::$app->session->setFlash('error', 'Wrong password!');
       }
     }
 
@@ -105,9 +90,9 @@ class ProfileController extends Controller {
 
     if ($model->load(Yii::$app->request->post())) {
       if($model->validate() && $model->changePassword()) {
-        Yii::$app->getSession()->setFlash('success', 'Password successfully changed');
+        Yii::$app->session->setFlash('success', 'Password successfully changed');
       } else {
-        Yii::$app->getSession()->setFlash('error', 'Wrong password!');
+        Yii::$app->session->setFlash('error', 'Wrong password!');
       }
     }
 
@@ -119,7 +104,7 @@ class ProfileController extends Controller {
 
     if ($model->load(Yii::$app->request->post()) && $model->validate()) {
       $model->changeEmail();
-      Yii::$app->getSession()->setFlash('success', "We've sent an email to your requested email address to confirm. Please click on the verification link to continue.");
+      Yii::$app->session->setFlash('success', "We've sent an email to your requested email address to confirm. Please click on the verification link to continue.");
     }
 
     $this->redirect(['profile/index']);

--- a/site/controllers/SiteController.php
+++ b/site/controllers/SiteController.php
@@ -4,7 +4,7 @@ namespace site\controllers;
 
 use Yii;
 use yii\web\BadRequestHttpException;
-use yii\web\Controller;
+use common\components\Controller;
 use yii\filters\VerbFilter;
 use common\components\AccessControl;
 
@@ -43,21 +43,6 @@ class SiteController extends Controller
         'actions' => [
           'logout' => ['post'],
         ],
-      ],
-    ];
-  }
-
-  /**
-   * @inheritdoc
-   */
-  public function actions()
-  {
-    return [
-      'error' => [
-        'class' => 'yii\web\ErrorAction',
-      ],
-      'captcha' => [
-        'class' => 'yii\captcha\CaptchaAction',
       ],
     ];
   }
@@ -139,7 +124,7 @@ class SiteController extends Controller
     $model = Yii::$container->get(\site\models\SignupForm::class);
     if($model->load(Yii::$app->request->post()) && $model->validate()) {
       $model->signup();
-      Yii::$app->getSession()->setFlash('success', 'We have sent a verification email to the email address you provided. Please check your inbox and follow the instructions to verify your account.');
+      Yii::$app->session->setFlash('success', 'We have sent a verification email to the email address you provided. Please check your inbox and follow the instructions to verify your account.');
       return $this->redirect('/',302);
     }
 
@@ -157,7 +142,7 @@ class SiteController extends Controller
         Yii::warning("$ip has tried to reset the password for ".$model->email);
       }
 
-      Yii::$app->getSession()->setFlash('success', 'If there is an account with the submitted email address you will receive further instructions in your email inbox.');
+      Yii::$app->session->setFlash('success', 'If there is an account with the submitted email address you will receive further instructions in your email inbox.');
       return $this->goHome();
     }
 
@@ -177,7 +162,7 @@ class SiteController extends Controller
     if ($model->load(Yii::$app->request->post())
         && $model->validate()
         && $model->resetPassword()) {
-      Yii::$app->getSession()->setFlash('success', 'New password was saved.');
+      Yii::$app->session->setFlash('success', 'New password was saved.');
       return $this->goHome();
     }
 
@@ -199,12 +184,12 @@ class SiteController extends Controller
     }
 
     if($user->isTokenConfirmed($user->verify_email_token)) {
-      Yii::$app->getSession()->setFlash('success', 'Your account has already been verified. Please log in.');
+      Yii::$app->session->setFlash('success', 'Your account has already been verified. Please log in.');
       return $this->redirect('/login',302);
     } else if (Yii::$app->getUser()->login($user)) {
       $user->confirmVerifyEmailToken();
       $user->save();
-      Yii::$app->getSession()->setFlash('success', 'Your account has been verified. Please continue with your check-in.');
+      Yii::$app->session->setFlash('success', 'Your account has been verified. Please continue with your check-in.');
       return $this->redirect('/welcome',302);
     }
   }

--- a/site/tests/unit/models/EditProfileFormTest.php
+++ b/site/tests/unit/models/EditProfileFormTest.php
@@ -6,6 +6,22 @@ use Yii;
 use \site\models\EditProfileForm;
 
 class EditProfileFormTest extends \Codeception\Test\Unit {
+	public $graph;
+	public $values = [
+			'timezone' => 'America/Los_Angeles',
+			'email_threshold' => 5,
+			'partner_email1' => 'partner1@example.com',
+			'partner_email2' => 'partner2@example.com',
+			'partner_email3' => 'partner3@example.com',
+			'expose_graph' => true,
+		];
+
+	public function setUp() {
+		$this->graph = $this->getMockBuilder(common\components\Graph::class)
+			->setMethods(['create', 'destroy'])
+			->getMock();
+		parent::setUp();
+	}
 
   public function testLoadUser() {
     $user = $this->getUser();
@@ -30,6 +46,54 @@ class EditProfileFormTest extends \Codeception\Test\Unit {
     expect('send_email should be false', $this->assertFalse($form->send_email));
   }
 
+  public function testSaveProfile() {
+    $user = $this->getUser();
+    $form = new \site\models\EditProfileForm($user);
+    $form->loadUser();
+
+    Yii::$container
+      ->set(\common\components\Graph::class, function () { return $this->graph; });
+    Yii::$container
+      ->set(\common\interfaces\UserBehaviorInterface::class, function () { return new FakeUserBehavior(); });
+
+    $form->attributes = $this->values;
+    expect('saveProfile should return the user', $this->assertEquals($user, $form->saveProfile()));
+		expect('saveProfile should set the user\'s attributes to be the form values', $this->assertEquals($this->values, $user->attributes));
+
+    $form->send_email = 'not_a_boolean';
+		$ret = $form->saveProfile();
+    expect('saveProfile should return the user with the partner-related settings equal to null', $this->assertNull($ret));
+
+		$null_vals = [
+			'email_threshold' => null,
+			'partner_email1'  => null,
+			'partner_email2'  => null,
+			'partner_email3'  => null,
+			'timezone'        => 'America/Los_Angeles',
+			'expose_graph'    => true,
+		];
+    $form->send_email = false;
+		$ret = $form->saveProfile();
+    expect('saveProfile should return the user with the partner-related settings equal to null', $this->assertEquals($null_vals, $user->attributes));
+
+		$this->graph
+			->expects($this->once())
+			->method('destroy');
+		$form->expose_graph = false;
+		$ret = $form->saveProfile();
+		expect('if form->expose_graph is set to false, destroy the graph and set user->expose_graph to false', $this->assertFalse($ret->expose_graph));
+
+		$this->graph
+			->expects($this->once())
+			->method('create');
+		$form->expose_graph = true;
+		$ret = $form->saveProfile();
+		expect('if form->expose_graph is set to true, create the graph and set user->expose_graph to true', $this->assertTrue($ret->expose_graph));
+		
+    $form->send_email = 'not_a_boolean';
+    expect('saveProfile should return null if the form validation fails', $this->assertNull($form->saveProfile()));
+  }
+
   private function getUser() {
     $user = $this->getmockbuilder('\common\models\user')
       ->disableoriginalconstructor()
@@ -44,11 +108,16 @@ class EditProfileFormTest extends \Codeception\Test\Unit {
       'expose_graph',
     ]);
     $user->timezone = 'America/Los_Angeles';
-    $user->email_threshold = 10;
-    $user->partner_email1 = 'partner1@email.com';
-    $user->partner_email2 = 'partner2@email.com';
-    $user->partner_email3 = 'partner3@email.com';
-    $user->expose_graph = false;
+    $user->email_threshold = 5;
+    $user->partner_email1 = 'partner1@example.com';
+    $user->partner_email2 = 'partner2@example.com';
+    $user->partner_email3 = 'partner3@example.com';
+    $user->expose_graph = true;
     return $user;
   }
+}
+
+class FakeUserBehavior {
+  public $scores = true;
+  public function calculateScoresOfLastMonth() { return $this->scores; }
 }

--- a/site/views/site/error.php
+++ b/site/views/site/error.php
@@ -13,7 +13,9 @@ use yii\helpers\Url;
 $this->title = "The Faster Scale App | $name";
 $code = $exception->statusCode;
 
-if($code === 404):
+$exception = Yii::$app->errorHandler->exception;
+
+if($exception instanceof \yii\web\NotFoundHttpException):
   $this->title = "The Faster Scale App | Page Not Found";
 ?>
 
@@ -23,9 +25,10 @@ if($code === 404):
   <p>Otherwise, please ensure your attempted url is correct.</p>
 
 <?php
-elseif($code >= 500 && $code < 600):
+elseif($exception instanceof \yii\web\ServerErrorHttpException):
   $this->title = "The Faster Scale App | Oops";
 ?>
+
   <h1>It's not you. It's us.</h1>
   <div class="alert alert-danger"><?= nl2br(Html::encode($name)) ?></div>
   <p>Well this is embarrassing...we're having an error on our side. So sorry for the annoyance. If you'd like to help, please send us a message on our <a href='<?=Url::to(['site/contact'])?>'>contact form</a>.</p>
@@ -38,4 +41,4 @@ elseif($code >= 500 && $code < 600):
   <p>The above error occurred while the Web server was processing your request.</p>
   <p>Please contact us if you think this is a server error. Thank you.</p>
 </div>
-<?php endif; ?> 
+<?php endif; ?>

--- a/site/widgets/Alert.php
+++ b/site/widgets/Alert.php
@@ -11,9 +11,9 @@ namespace site\widgets;
  * Alert widget renders a message from session flash. All flash messages are displayed
  * in the sequence they were assigned using setFlash. You can set message as following:
  *
- * - \Yii::$app->getSession()->setFlash('error', 'This is the message');
- * - \Yii::$app->getSession()->setFlash('success', 'This is the message');
- * - \Yii::$app->getSession()->setFlash('info', 'This is the message');
+ * - \Yii::$app->session->setFlash('error', 'This is the message');
+ * - \Yii::$app->session->setFlash('success', 'This is the message');
+ * - \Yii::$app->session->setFlash('info', 'This is the message');
  *
  * @author Kartik Visweswaran <kartikv2@gmail.com>
  * @author Alexander Makarov <sam@rmcreative.ru>
@@ -43,7 +43,7 @@ class Alert extends \yii\bootstrap\Widget
     {
         parent::init();
 
-        $session = \Yii::$app->getSession();
+        $session = \Yii::$app->session;
         $flashes = $session->getAllFlashes();
         $appendCss = isset($this->options['class']) ? ' ' . $this->options['class'] : '';
 
@@ -60,8 +60,6 @@ class Alert extends \yii\bootstrap\Widget
                     'closeButton' => $this->closeButton,
                     'options' => $this->options,
                 ]);
-
-                $session->removeFlash($type);
             }
         }
     }


### PR DESCRIPTION
- Instead of taking the user to a confusing error page
- Also changes getSession() calls to just 'session'