### PR TITLE
Fixes bug on /checkin/report page

### DIFF
--- a/common/tests/unit/models/UserBehaviorTest.php
+++ b/common/tests/unit/models/UserBehaviorTest.php
@@ -314,6 +314,7 @@ class UserBehaviorTest extends \Codeception\Test\Unit {
     expect('rules', $this->assertEquals($this->user_behavior->rules(), [
       [['user_id', 'behavior_id', 'category_id', 'date'], 'required'],
       [['user_id', 'behavior_id', 'category_id'], 'integer'],
+      ['custom_behavior', 'string'],
     ]));
   }
 
@@ -324,6 +325,7 @@ class UserBehaviorTest extends \Codeception\Test\Unit {
       'user_id'   => 'User ID',
       'behavior_id' => 'Behavior ID',
       'category_id' => 'Category ID',
+      'custom_behavior' => 'Personal Behavior Name',
     ]));
   }
 


### PR DESCRIPTION
Top Behaviors threw an error when only Personal Behaviors had been
selected.

Also adds custom_behavior to the UserBehavior model rules and deletes a
broken and unused relation in that model.

| Q                      | A
| -------------          | ---
| Is it a bugfix?        | yes
| Is it a new feature?   | no
| Do tests pass?         | yes