### PR TITLE
Fixes #194: Incorrect association of question answers to behaviors

### DIFF
--- a/site/models/QuestionForm.php
+++ b/site/models/QuestionForm.php
@@ -157,7 +157,29 @@ class QuestionForm extends Model
     public function getAnswers($bhvrs)
     {
         $answers = [];
-        $user_bhvrs = array_combine($this->getUserBehaviorProps(), $bhvrs);
+
+        /*
+         * Fixes issue #194 with processing question answers for custom behaviors
+         *
+         * Answers were not correctly associated with custom behaviors due to an incorrect
+         * assumption that they were inserted into the DB in the typical FASTER order.
+         *
+         * We set the array keys to be the category ids then sort the array by key. This
+         * ensures our behaviors are in the FASTER order.
+         *
+         * NOTE: This further entrenches us in the assumption that we are
+         * processing one-and-only-one behavior per category. This logic will
+         * break if that assumption becomes invalid as we're indexing the
+         * array on category_id.
+         */
+        $bhvrs2 = [];
+        foreach($bhvrs as $b) {
+            $bhvrs2[$b->category_id] = $b;
+        }
+        ksort($bhvrs2);
+        /* ** ** */
+
+        $user_bhvrs = array_combine($this->getUserBehaviorProps(), $bhvrs2);
         foreach ($user_bhvrs as $property => $user_bhvr) {
             $behavior_id = intval(substr($property, -1, 1));
             foreach ($this->behaviorToAnswers($behavior_id) as $answer_letter => $answer) {

--- a/site/tests/unit/models/QuestionFormTest.php
+++ b/site/tests/unit/models/QuestionFormTest.php
@@ -129,42 +129,42 @@ class QuestionFormTest extends \Codeception\Test\Unit
             $model->answer_3c = "processing emotions";
 
             expect('getAnswers should extract and coerce the data correctly', $this->assertEquals($model->getAnswers([
-        $this->fakeModel(7, 280, 8),
-        $this->fakeModel(13, 281, 8),
+        $this->fakeModel(7, 280, 6),
+        $this->fakeModel(13, 281, 7),
         $this->fakeModel(28, 284, 8)
       ]), [ [
                                         'behavior_id' => 280,
-                    'category_id' => 8,
+                    'category_id' => 6,
                                         'user_bhvr_id' => 7,
                                         'question_id' => 1,
                                         'answer' => 'processing emotions',
                                     ], [
                                         'behavior_id' => 280,
-                    'category_id' => 8,
+                    'category_id' => 6,
                                         'user_bhvr_id' => 7,
                                         'question_id' => 2,
                                         'answer' => 'processing emotions',
                                     ], [
                                         'behavior_id' => 280,
-                    'category_id' => 8,
+                    'category_id' => 6,
                                         'user_bhvr_id' => 7,
                                         'question_id' => 3,
                                         'answer' => 'processing emotions',
                                     ], [
                                         'behavior_id' => 281,
-                    'category_id' => 8,
+                    'category_id' => 7,
                                         'user_bhvr_id' => 13,
                                         'question_id' => 1,
                                         'answer' => 'processing emotions',
                                     ], [
                                         'behavior_id' => 281,
-                    'category_id' => 8,
+                    'category_id' => 7,
                                         'user_bhvr_id' => 13,
                                         'question_id' => 2,
                                         'answer' => 'processing emotions',
                                     ], [
                                         'behavior_id' => 281,
-                    'category_id' => 8,
+                    'category_id' => 7,
                                         'user_bhvr_id' => 13,
                                         'question_id' => 3,
                                         'answer' => 'processing emotions',


### PR DESCRIPTION
The code incorrectly assumed behaviors pulled from the DB were in FASTER order. Custom behaviors require special handling on DB insert and were inserted last (and have the highest auto-generated IDs). We zipped up two arrays (user_behavior_id* and the user_behavior model instances) so some user_behavior models were not assigned to their correct user_behavior_id* property on the QuestionForm instance.

Now we sort the array of user_behavior models by their category_id before zipping up the two arrays. This gives us the correct association.

| Q                      | A
| -------------          | ---
| Is it a bugfix?        | yes
| Is it a new feature?   | no
| Do tests pass?         | yes
| Related PRs or Issues  | #194